### PR TITLE
fix(a11y): remove duplicate initAccessibility placeholder

### DIFF
--- a/footer.js
+++ b/footer.js
@@ -462,14 +462,6 @@ function initIconFix() {
 }
 
 // =============================================
-// MODULE 6: ACCESSIBILITY HELPERS (PLACEHOLDER)
-// =============================================
-
-function initAccessibility() {
-  // Add accessibility enhancements here
-}
-
-// =============================================
 // MODULE 7: ANALYTICS & TRACKING (PLACEHOLDER)
 // =============================================
 


### PR DESCRIPTION
## Summary

Follow-up to #1. After deploy, re-audit showed JS-based a11y fixes weren't applying (landmark, link-name, heading-order still failed). Root cause: a pre-existing empty `initAccessibility()` stub at line 468 was declared *after* my real implementation (line 65), so JavaScript hoisting gave the empty version priority at runtime.

Removing the stub restores the real implementation.

## Test plan

- [ ] After merge, purge jsDelivr CDN
- [ ] Re-run Lighthouse on `/` — expect score to jump from 89 to ~95+
- [ ] Verify `role="main"` present on first non-modal section
- [ ] Verify `aria-label` on `a.logo` and social icons