### PR TITLE
docs(claude): point Compliance Profile at canonical BDS doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ TNCLD is a dental practice in Franklin, TN. Regulatory regimes that apply:
 
 **Accessibility target:** WCAG 2.1 Level AA (the standard DOJ applies under Title III). No AAA bump.
 
-**Canonical accessibility + compliance standard:** [markdown/legal-drafts/BRIK-HEALTHCARE-ADA-STANDARDS.md](markdown/legal-drafts/BRIK-HEALTHCARE-ADA-STANDARDS.md) — staging for promotion to `brik/brik-bds/content-system/compliance/healthcare-ada.md`. Every content or design change to this site must honor that standard.
+**Canonical accessibility + compliance standard:** [`@brikdesigns/bds/content-system/compliance/healthcare-ada.md`](https://design.brikdesigns.com/docs/content-system/compliance/Healthcare-ADA) — promoted to BDS 2026-04-21. The TNCLD remediation work seeded this canonical doc; the original draft at [markdown/legal-drafts/BRIK-HEALTHCARE-ADA-STANDARDS.md](markdown/legal-drafts/BRIK-HEALTHCARE-ADA-STANDARDS.md) is retained only as historical reference. Every content or design change to this site must honor the canonical BDS doc. Companion: [`brik-llm/websites/shared/CLIENT-ACCESSIBILITY-STANDARDS.md`](https://github.com/brikdesigns/brik-llm/blob/main/websites/shared/CLIENT-ACCESSIBILITY-STANDARDS.md) — universal Brik a11y baseline.
 
 **Required roles at TNCLD:**
 - **HIPAA Privacy Officer** (45 CFR § 164.530) — must be a named individual; appears in Privacy Policy + NPP


### PR DESCRIPTION
TNCLD's Compliance Profile previously pointed at the local draft at `markdown/legal-drafts/BRIK-HEALTHCARE-ADA-STANDARDS.md`. That doc was promoted to canonical BDS location (`@brikdesigns/bds/content-system/compliance/healthcare-ada.md`) on 2026-04-21. This PR updates the link to point at canonical and adds a cross-link to the universal Brik a11y baseline.

Refs [brik-llm#130](https://github.com/brikdesigns/brik-llm/issues/130) phase 4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)