### PR TITLE
ci(security): add gitleaks secret scan on PRs

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,43 @@
+name: Secret scan
+
+# Why: defense-in-depth for the secret-leak prevention layer. Closes the
+# coverage gap surfaced in brik-llm#625 (security maturity roadmap):
+# tncld was one of 3 Brik repos missing gitleaks CI as of 2026-05-23.
+#
+# Scope: scans the PR's diff against the base branch, not full history.
+# Historic leaks (if any) need rotation per brik-llm/operations/security/when-to-rotate.md;
+# blocking unrelated PRs on them is the wrong gate. New leaks introduced by a
+# PR are caught.
+#
+# Implementation note: uses the gitleaks CLI binary directly. gitleaks-action@v2
+# requires a paid GITLEAKS_LICENSE for any GitHub organization (recent breaking
+# change); the CLI itself is MIT-licensed.
+#
+# Canonical template: brik-llm/.github/workflows/gitleaks.yml (kept in sync).
+
+on:
+  pull_request:
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          set -e
+          VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Scan PR diff
+        run: |
+          set -e
+          config_arg=""
+          [ -f .gitleaks.toml ] && config_arg="--config .gitleaks.toml"
+          gitleaks detect --redact --no-banner --verbose --exit-code 1 $config_arg \
+            --log-opts="--no-merges origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/gitleaks.yml` to close a coverage gap surfaced in the 2026-05-23 strategic security audit (brikdesigns/brik-llm#625, child #628).

tncld was 1 of 3 Brik repos missing gitleaks CI; **public repo = highest-exposure surface** for an accidental secret commit becoming permanently public.

Canonical template kept in sync with [brik-llm/.github/workflows/gitleaks.yml](https://github.com/brikdesigns/brik-llm/blob/main/.github/workflows/gitleaks.yml). Scans PR diff against the base branch — not full history. Historic leaks (if any surfaced) get rotated per [`when-to-rotate.md`](https://github.com/brikdesigns/brik-llm/blob/main/operations/security/when-to-rotate.md), not blocked here.

## Test plan

- [ ] Workflow appears on `Actions` tab after merge
- [ ] First PR after merge triggers the workflow + completes
- [ ] Any findings → rotation issue per Brik doctrine, not a blocker for this PR's merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs brikdesigns/brik-llm#628