### PR TITLE
ci(security): add Husky + gitleaks pre-commit (closes Layer 4 gap)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,22 @@
+# ── Secret scan (gitleaks) ──
+# Defense-in-depth for the secret-leak prevention layer. Mirrors the pattern
+# used in brik-bds, brik-client-portal, renew-pms, brikdesigns. Runs gitleaks
+# on the staged diff; blocks commits containing patterns that match its
+# built-in rules + any local .gitleaks.toml allowlist. Graceful skip if
+# gitleaks isn't installed (CI / fresh machine).
+#
+# Canonical template: brik-bds/.husky/pre-commit. Layer-4 entry in
+# brik-llm/operations/security/security-layers.md.
+if command -v gitleaks >/dev/null 2>&1; then
+  echo "🔍 Running gitleaks secret scan..."
+  config_arg=""
+  if [ -f .gitleaks.toml ]; then
+    config_arg="--config .gitleaks.toml"
+  fi
+  if ! gitleaks protect --staged --redact --no-banner --verbose $config_arg; then
+    echo ""
+    echo "   Secret detected in staged changes. Move the value to ~/.secrets/<name>.env"
+    echo "   and reference it via process.env.<NAME>. If false positive, add to .gitleaks.toml."
+    exit 1
+  fi
+fi

--- a/json/package-lock.json
+++ b/json/package-lock.json
@@ -14,6 +14,9 @@
         "dotenv": "^16.6.1",
         "fs-extra": "^11.1.1"
       },
+      "devDependencies": {
+        "husky": "^9.1.7"
+      },
       "engines": {
         "node": ">=16.0.0"
       }
@@ -300,6 +303,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/jsonfile": {

--- a/json/package.json
+++ b/json/package.json
@@ -27,7 +27,8 @@
     "setup-copilot": "node scripts/setup-copilot-onlook.js",
     "open-onlook": "echo \"Visit https://onlook.com to connect your repository\"",
     "copilot-guide": "open VISUAL_COPILOT_GUIDE.md",
-    "onlook-guide": "open ONLOOK_GUIDE.md"
+    "onlook-guide": "open ONLOOK_GUIDE.md",
+    "prepare": "husky"
   },
   "keywords": [
     "webflow",
@@ -48,5 +49,8 @@
   "bugs": {
     "url": "https://github.com/brikdesigns/tncld/issues"
   },
-  "homepage": "https://tncld.com/"
+  "homepage": "https://tncld.com/",
+  "devDependencies": {
+    "husky": "^9.1.7"
+  }
 }


### PR DESCRIPTION
## Summary

Closes the Layer 4 (local pre-commit) gap for tncld. Refs [brik-llm#625](https://github.com/brikdesigns/brik-llm/issues/625) (security maturity roadmap).

tncld was one of 3 Brik repos lacking ANY local pre-commit hook as of 2026-05-24 — **public repo where any committed credential becomes permanently public**.

## What

- Add `husky@^9` as a devDependency (at `json/package.json` — repo-root package.json is a symlink there)
- Add `"prepare": "husky"` to scripts
- Add `.husky/pre-commit` running `gitleaks protect --staged` (graceful skip if CLI not installed)

Template matches brik-bds, brik-client-portal, renew-pms, brikdesigns#274.

## Note on the 2-commit history

tncld's `package.json` is a symlink at the repo root pointing at `json/package.json`. First commit landed `.husky/pre-commit` but staged the symlink (unchanged) rather than its target. Followup commit catches up the actual json/ files so `npm install` auto-installs Husky on fresh checkouts.

## Test plan

- [x] `npm install` succeeds; Husky auto-installs via prepare script
- [x] `.husky/pre-commit` is executable
- [ ] Make a benign commit on a task branch — pre-commit runs, exits 0
- [ ] Make a commit with a fake `ghp_` PAT — pre-commit blocks; commit refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs brikdesigns/brik-llm#625