### PR TITLE
a11y(forms): per-field error announcements for /contact + /request-appointment

### DIFF
--- a/footer.js
+++ b/footer.js
@@ -68,6 +68,7 @@ function initAccessibility() {
     labelLogoLinks();
     labelSocialIcons();
     demoteEyebrowHeadings();
+    initFormErrorAnnouncements();
   } catch (err) {
     console.warn('a11y init error:', err);
   }
@@ -134,6 +135,214 @@ function demoteEyebrowHeadings() {
       h.setAttribute('role', 'presentation');
     }
   });
+}
+
+// Per-field error announcement for /contact + /request-appointment forms.
+// Webflow's native form UX shows a single generic .w-form-fail banner
+// ("Oops! Something went wrong...") which is too vague for healthcare
+// users and not announced by screen readers. This wires:
+//   - role="alert" + aria-live="polite" on .w-form-fail and .w-form-done
+//   - Per-field error containers linked via aria-describedby
+//   - Plain-language messages from HTML5 Constraint Validation
+//   - novalidate on the form to suppress duelling browser-native popups
+//   - Capture-phase submit handler so validation runs before Webflow's
+//     own jQuery submit handler (we preventDefault if invalid, otherwise
+//     pass through unchanged)
+//   - Focus moves to first invalid field on submit failure
+//   - Errors auto-clear when the user starts correcting the field
+// Targets only the two known healthcare forms by ID; safe no-op elsewhere.
+function initFormErrorAnnouncements() {
+  var forms = document.querySelectorAll(
+    '#wf-form-Contact-Us-Form, #wf-form-Request-Appointment-Form'
+  );
+  if (!forms.length) return;
+  forms.forEach(enhanceFormErrors);
+  console.log('Form error announcements initialized:', forms.length, 'form(s)');
+}
+
+function enhanceFormErrors(form) {
+  if (form.dataset.a11yEnhanced === 'true') return;
+  form.dataset.a11yEnhanced = 'true';
+
+  // Suppress browser-native validity popups so our custom messages win
+  form.setAttribute('novalidate', '');
+
+  // Mark Webflow's success + failure regions as live so SR announces them
+  var wrapper = form.closest('.w-form');
+  if (wrapper) {
+    var failDiv = wrapper.querySelector('.w-form-fail');
+    if (failDiv) {
+      failDiv.setAttribute('role', 'alert');
+      failDiv.setAttribute('aria-live', 'polite');
+    }
+    var doneDiv = wrapper.querySelector('.w-form-done');
+    if (doneDiv) {
+      doneDiv.setAttribute('role', 'status');
+      doneDiv.setAttribute('aria-live', 'polite');
+    }
+  }
+
+  // Build per-field error containers + wire aria-describedby
+  var fields = collectValidatableFields(form);
+  fields.forEach(function(field) {
+    ensureErrorContainer(form, field);
+    field.addEventListener('input', function() { clearFieldError(field); });
+    field.addEventListener('change', function() { clearFieldError(field); });
+  });
+
+  // Capture-phase submit handler — runs before Webflow's jQuery handler
+  form.addEventListener('submit', function(e) {
+    var invalid = validateFormFields(form);
+    if (invalid.length > 0) {
+      e.preventDefault();
+      e.stopPropagation();
+      invalid.forEach(function(item) {
+        showFieldError(item.field, item.message);
+      });
+      // Move focus to the first invalid field for keyboard + SR users
+      try { invalid[0].field.focus({ preventScroll: false }); } catch (err) {}
+    }
+  }, true);
+}
+
+function collectValidatableFields(form) {
+  var nodes = form.querySelectorAll('input, textarea, select');
+  var fields = [];
+  for (var i = 0; i < nodes.length; i++) {
+    var f = nodes[i];
+    var type = (f.type || '').toLowerCase();
+    if (type === 'submit' || type === 'button' || type === 'hidden' || type === 'reset') continue;
+    if (!f.id) continue;
+    fields.push(f);
+  }
+  return fields;
+}
+
+function ensureErrorContainer(form, field) {
+  var errorId = field.id + '-error';
+  var existing = form.querySelector('#' + cssEscape(errorId));
+  if (existing) {
+    appendDescribedBy(field, errorId);
+    return;
+  }
+  var errorEl = document.createElement('div');
+  errorEl.id = errorId;
+  errorEl.className = 'field-error';
+  errorEl.setAttribute('aria-live', 'polite');
+  errorEl.hidden = true;
+  // Insert directly after the field — keeps the error inside the field's
+  // wrapper for layout, and right after the input in DOM order for SR.
+  if (field.nextSibling) {
+    field.parentNode.insertBefore(errorEl, field.nextSibling);
+  } else {
+    field.parentNode.appendChild(errorEl);
+  }
+  appendDescribedBy(field, errorId);
+}
+
+function appendDescribedBy(field, errorId) {
+  var current = field.getAttribute('aria-describedby') || '';
+  var ids = current.split(/\s+/).filter(Boolean);
+  if (ids.indexOf(errorId) === -1) {
+    ids.push(errorId);
+    field.setAttribute('aria-describedby', ids.join(' '));
+  }
+}
+
+function validateFormFields(form) {
+  var invalid = [];
+  collectValidatableFields(form).forEach(function(field) {
+    var msg = getFieldErrorMessage(field);
+    if (msg) invalid.push({ field: field, message: msg });
+  });
+  return invalid;
+}
+
+// Plain-language messages derived from HTML5 Constraint Validation.
+// Healthcare standard wants natural language ("Please enter your email"),
+// not browser-default strings like "Invalid value."
+function getFieldErrorMessage(field) {
+  if (typeof field.checkValidity !== 'function') return null;
+  if (field.checkValidity()) return null;
+
+  var v = field.validity;
+  var label = getFieldLabelText(field);
+
+  if (v.valueMissing) {
+    if (field.type === 'checkbox' || field.type === 'radio') {
+      return 'Please check ' + label;
+    }
+    if (field.tagName === 'SELECT') {
+      return 'Please choose ' + label;
+    }
+    return 'Please enter your ' + label.toLowerCase();
+  }
+  if (v.typeMismatch && field.type === 'email') {
+    return 'Please enter a valid email address';
+  }
+  if (v.typeMismatch && field.type === 'url') {
+    return 'Please enter a valid URL';
+  }
+  if (v.tooShort) {
+    return label + ' must be at least ' + field.minLength + ' characters';
+  }
+  if (v.tooLong) {
+    return label + ' must be no more than ' + field.maxLength + ' characters';
+  }
+  if (v.patternMismatch) {
+    return 'Please match the requested format for ' + label.toLowerCase();
+  }
+  return 'Please correct ' + label.toLowerCase();
+}
+
+// Resolve a human-readable label name in priority order:
+//   1. aria-labelledby target text (preferred — matches our Designer wiring)
+//   2. aria-label attribute
+//   3. .labels collection (native <label for=>)
+//   4. The field's name attribute
+// Strips a trailing " *" required indicator so messages read naturally.
+function getFieldLabelText(field) {
+  var labelText = '';
+  var labelledBy = field.getAttribute('aria-labelledby');
+  if (labelledBy) {
+    var lbl = document.getElementById(labelledBy);
+    if (lbl) labelText = lbl.textContent;
+  }
+  if (!labelText) {
+    labelText = field.getAttribute('aria-label') || '';
+  }
+  if (!labelText && field.labels && field.labels.length) {
+    labelText = field.labels[0].textContent;
+  }
+  if (!labelText) labelText = field.name || 'this field';
+  return labelText.trim().replace(/\s*\*\s*$/, '');
+}
+
+function showFieldError(field, message) {
+  var errorEl = document.getElementById(field.id + '-error');
+  if (!errorEl) return;
+  errorEl.textContent = message;
+  errorEl.hidden = false;
+  field.setAttribute('aria-invalid', 'true');
+}
+
+function clearFieldError(field) {
+  var errorEl = document.getElementById(field.id + '-error');
+  if (!errorEl) return;
+  if (errorEl.hidden) return;
+  errorEl.textContent = '';
+  errorEl.hidden = true;
+  field.removeAttribute('aria-invalid');
+}
+
+// CSS.escape polyfill — Webflow auto-generated IDs can contain
+// characters that need escaping in selectors (none in this site
+// today, but cheap insurance against future IDs).
+function cssEscape(value) {
+  if (window.CSS && typeof window.CSS.escape === 'function') {
+    return window.CSS.escape(value);
+  }
+  return String(value).replace(/([^a-zA-Z0-9_-])/g, '\\$1');
 }
 
 // =============================================

--- a/header.css
+++ b/header.css
@@ -503,6 +503,33 @@ select:focus-visible,
   border: 0 !important;
 }
 
+/* Per-field form error messages injected by footer.js
+   initFormErrorAnnouncements. Uses a non-color cue (warning glyph) in
+   addition to red text, so users who can't perceive color still get
+   the error signal. #b91c1c is 6.4:1 against #ffffff (passes AA). */
+.field-error {
+  display: block;
+  margin-top: 6px;
+  color: #b91c1c;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  font-weight: 500;
+}
+.field-error::before {
+  content: "⚠ ";
+  font-weight: 700;
+}
+.field-error[hidden] {
+  display: none;
+}
+/* Visible field-level error treatment on the input itself */
+input[aria-invalid="true"],
+textarea[aria-invalid="true"],
+select[aria-invalid="true"] {
+  border-color: #b91c1c !important;
+  box-shadow: 0 0 0 1px #b91c1c;
+}
+
 /* ============================================= */
 /*        RESPONSIVE - TABLET & MOBILE          */
 /* ============================================= */


### PR DESCRIPTION
## Summary

Adds `initFormErrorAnnouncements` to the existing `initAccessibility` module in `footer.js`, closing the S3 error-wiring gap from the recent contact-form + request-appointment accessibility assessment.

Targets `#wf-form-Contact-Us-Form` and `#wf-form-Request-Appointment-Form` by id; safe no-op everywhere else.

### What it wires

- `role="alert"` + `aria-live="polite"` on Webflow's `.w-form-fail` / `.w-form-done`
- Per-field `<div class="field-error" aria-live="polite" hidden>` after each validatable input, linked via `aria-describedby`
- `novalidate` on the form so custom messages win over browser-native popups
- Capture-phase submit handler — runs before Webflow's bubble-phase jQuery handler. Validates via HTML5 Constraint Validation. On invalid: `preventDefault` + `stopPropagation`, populate error containers, focus the first invalid field. On valid: silent pass-through to Webflow's submit pipeline.
- Plain-language messages: `valueMissing` → "Please enter your email", `typeMismatch` on email → "Please enter a valid email address", etc.
- Errors auto-clear on `input`/`change`

### Companion CSS (`header.css`)

- `.field-error`: `#b91c1c` (6.4:1 on white, AA), bold weight, ⚠ glyph prefix so the error signal doesn't depend on color perception alone
- `[aria-invalid="true"]` inputs get a red border + halo

### Pairs with staged Webflow Designer canvas changes

This PR is the CDN half. The Designer half (POST method, `aria-labelledby` wiring, visible `*` on required fields, unique select IDs, autocomplete tokens) is staged on the TNCLD Webflow canvas but not yet published. **Both halves should go live together** for the full a11y win.

Standard applied: WCAG 2.1 AA + Brik [CLIENT-ACCESSIBILITY-STANDARDS.md](../../brik/brik-llm/blob/main/websites/shared/CLIENT-ACCESSIBILITY-STANDARDS.md#elevated-standard---healthcare-adjacent-clients) elevated (healthcare).

## Test plan

After merge → `bash deploy.sh` → Webflow Designer publish to staging (`tncld.webflow.io`):

- [ ] On `tncld.webflow.io/contact`, tab through form. Confirm focus ring visible on every field.
- [ ] Submit `/contact` with Email empty → confirm visible error "Please enter your email" appears under the field + focus moves to Email + VoiceOver announces the error
- [ ] Submit `/contact` with Email = "notanemail" → confirm "Please enter a valid email address"
- [ ] Submit `/contact` with valid data → confirm normal Webflow success path fires (`.w-form-done` shows, SR announces it)
- [ ] On `/request-appointment`, repeat: submit empty → "Please enter your phone *" message under Phone
- [ ] Verify each select label announces its own name in VoiceOver (Reason for Your Visit / Preferred Day / Preferred Time), not the first label for all three
- [ ] Confirm test submission arrives in Webflow Forms tab (validates GET→POST change works end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)