### PR TITLE
ci(infra): adopt canonical Brik gitleaks rule set

### DIFF
--- a/.brik-gitleaks-rules.toml
+++ b/.brik-gitleaks-rules.toml
@@ -1,0 +1,93 @@
+# Brik canonical gitleaks rules — DO NOT EDIT IN PLACE.
+#
+# Source of truth:
+#   brik-llm/scripts/shared/security/templates/.brik-gitleaks-rules.toml
+# Synced via:
+#   brik-llm/scripts/shared/security/sync.sh
+#
+# Edits made directly to a downstream copy will be clobbered on next sync.
+# To add or change a rule: edit the source, then run sync.sh to propagate.
+#
+# This file is consumed by each repo's .gitleaks.toml via:
+#   [extend]
+#   path = ".brik-gitleaks-rules.toml"
+#
+# The consuming file MUST NOT also set `useDefault = true` at that level —
+# gitleaks v8.30.1 errors at load: "unable to load config due to extend.path
+# and extend.useDefault being set". Instead, `useDefault = true` is declared
+# in this canonical file (below), and gitleaks chains it through
+# `[extend].path` so consuming configs inherit the bundled default ruleset.
+# This also lets the canonical work standalone (gitleaks-cli'd directly).
+
+[extend]
+useDefault = true
+
+# ── Anthropic ───────────────────────────────────────────────────────────────
+
+[[rules]]
+id = "anthropic-api-key"
+description = "Anthropic API key (sk-ant-api03-...)"
+regex = '''sk-ant-api(?:01|02|03)-[A-Za-z0-9_\-]{40,}'''
+keywords = ["sk-ant-api"]
+
+[[rules]]
+id = "anthropic-oauth-bearer"
+description = "Anthropic OAuth bearer (claude-cli)"
+regex = '''sk-ant-oat[0-9]{2}-[A-Za-z0-9_\-]{40,}'''
+keywords = ["sk-ant-oat"]
+
+# ── Notion ──────────────────────────────────────────────────────────────────
+
+[[rules]]
+id = "notion-integration-token"
+description = "Notion integration token (ntn_...)"
+regex = '''ntn_[A-Za-z0-9]{40,}'''
+keywords = ["ntn_"]
+
+# ── Slack ───────────────────────────────────────────────────────────────────
+
+[[rules]]
+id = "slack-bot-token"
+description = "Slack bot token (xoxb-...)"
+regex = '''xoxb-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{20,}'''
+keywords = ["xoxb-"]
+
+[[rules]]
+id = "slack-app-token"
+description = "Slack app-level token (xapp-...)"
+regex = '''xapp-[0-9]+-[A-Z0-9]+-[0-9]+-[a-f0-9]{40,}'''
+keywords = ["xapp-"]
+
+[[rules]]
+id = "slack-user-token"
+description = "Slack user/admin/refresh token (xoxp/xoxa/xoxr/xoxs)"
+regex = '''xox[apsr]-[0-9]{10,}-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{30,}'''
+keywords = ["xoxp-", "xoxa-", "xoxs-", "xoxr-"]
+
+# ── Helicone ────────────────────────────────────────────────────────────────
+
+[[rules]]
+id = "helicone-key"
+description = "Helicone API key (sk-helicone-...)"
+regex = '''sk-helicone-[A-Za-z0-9_\-]{20,}'''
+keywords = ["sk-helicone"]
+
+# ── Voyage ──────────────────────────────────────────────────────────────────
+
+[[rules]]
+id = "voyage-api-key"
+description = "Voyage AI API key (pa-...)"
+regex = '''pa-[A-Za-z0-9]{40,}'''
+keywords = ["pa-"]
+
+# ── Webflow ─────────────────────────────────────────────────────────────────
+# Catches the pattern that triggered the 2026-01-13 historical leak
+# (publish-webflow.js / publish-webflow-test.js) which slipped past GitHub
+# server-side scanning. Generic-api-key already catches this shape, but a
+# named rule produces a clearer finding in CI/hook output.
+
+[[rules]]
+id = "webflow-v1-api-token"
+description = "Webflow API v1 token assigned to a credential-shaped variable (64-char hex)"
+regex = '''(?i)(?:api[_-]?token|webflow[_-]?(?:api[_-]?)?(?:token|key))\s*=\s*['"`]([0-9a-f]{64})['"`]'''
+keywords = ["api_token", "API_TOKEN", "webflow"]

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,22 +1,30 @@
 name: Secret scan
 
-# Why: defense-in-depth for the secret-leak prevention layer. Closes the
-# coverage gap surfaced in brik-llm#625 (security maturity roadmap):
-# tncld was one of 3 Brik repos missing gitleaks CI as of 2026-05-23.
+# Brik canonical gitleaks CI — DO NOT EDIT IN PLACE.
+#
+# Source of truth:
+#   brik-llm/scripts/shared/security/templates/gitleaks.yml
+# Synced via:
+#   brik-llm/scripts/shared/security/sync.sh
+#
+# Why: defense-in-depth for the secret-leak prevention layer shipped 2026-05-04
+# (renew-pms#258 hooks + brik-llm#193 follow-up).
 #
 # Scope: scans the PR's diff against the base branch, not full history.
-# Historic leaks (if any) need rotation per brik-llm/operations/security/when-to-rotate.md;
-# blocking unrelated PRs on them is the wrong gate. New leaks introduced by a
-# PR are caught.
+# Historic leaks need rotation (separate work — see brik-llm#193 Phase 4
+# punch list); blocking unrelated PRs on them is the wrong gate. New leaks
+# introduced by a PR are caught.
 #
 # Implementation note: uses the gitleaks CLI binary directly. gitleaks-action@v2
 # requires a paid GITLEAKS_LICENSE for any GitHub organization (recent breaking
 # change); the CLI itself is MIT-licensed.
-#
-# Canonical template: brik-llm/.github/workflows/gitleaks.yml (kept in sync).
 
 on:
   pull_request:
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   gitleaks:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,41 @@
+# Gitleaks config for tncld.
+# Extends the Brik canonical rule set (sync-managed) with this repo's allowlist.
+#
+# Canonical rules live in .brik-gitleaks-rules.toml — that file is synced from
+# brik-llm/scripts/shared/security/templates/.brik-gitleaks-rules.toml via
+# brik-llm/scripts/shared/security/sync.sh. Do not edit .brik-gitleaks-rules.toml
+# in this repo — edits will be clobbered on next sync.
+#
+# This file (.gitleaks.toml) is hand-managed by each repo. Add repo-specific
+# allowlist paths or rule overrides here.
+#
+# See https://github.com/gitleaks/gitleaks#configuration for syntax.
+
+[extend]
+# Only `path` is declared here. The canonical file (.brik-gitleaks-rules.toml)
+# itself declares `useDefault = true`, and gitleaks v8.30.1 chains that through
+# `[extend].path`, so the bundled default ruleset is inherited automatically.
+# Setting both `useDefault` and `path` at the same level is a gitleaks load
+# error: "unable to load config due to extend.path and extend.useDefault being
+# set". If you ever consume a canonical that lacks `useDefault`, declare it here
+# instead of path-chaining.
+path = ".brik-gitleaks-rules.toml"
+
+# ── Allowlist ───────────────────────────────────────────────────────────────
+# Files known to contain placeholder/test values, not real secrets.
+# The four entries below are the Brik-universal baseline — copy them into any
+# new repo's allowlist. Add repo-specific paths beneath them.
+
+[allowlist]
+description = "tncld allowlist — universal baseline + repo-local"
+paths = [
+  '''(.*/)?\.env\.example$''',
+  '''(.*/)?\.env\.template$''',
+  '''(.*/)?CLAUDE\.md$''',
+  '''(.*/)?\.gitleaks\.toml$''',
+  # ── tncld-specific ──────────────────────────────────────────────────────
+  # Webflow's bundled JS runtime ships with public client-side identifiers
+  # (e.g. Google Maps API key for the map widget) that fire on `gcp-api-key`.
+  # These are baked into Webflow's product, not Brik secrets — safe to skip.
+  '''(.*/)?js/webflow\.js$''',
+]


### PR DESCRIPTION
## Summary

Cluster H Session 5 — fifth (final) per-repo migration. Closes the cluster H coverage gap: `tncld` was one of three Brik repos brikdesigns/brik-llm#625 flagged as PUBLIC with no gitleaks CI. Adopts the canonical rule set via the same recipe used in #787 (brik-bds), brikdesigns/renew-pms#336, brikdesigns/brik-llm#711, brikdesigns/brikdesigns#296.

`tncld` had no `.gitleaks.toml` at all before this PR — bootstrapped via `sync.sh --apply --bootstrap`.

## Net coverage change: +9 rules

Before this PR `tncld` had **zero** gitleaks config. After, it inherits the full canonical rule set plus the bundled gitleaks default ruleset (chained through via `[extend].path` per brikdesigns/brik-llm#707).

| Rule | Before | After |
|---|---|---|
| `anthropic-api-key`, `anthropic-oauth-bearer` | ❌ | ✅ (via canonical) |
| `notion-integration-token` | ❌ | ✅ (via canonical) |
| `slack-bot-token`, `slack-app-token`, `slack-user-token` | ❌ | ✅ (via canonical) |
| `helicone-key`, `voyage-api-key` | ❌ | ✅ (via canonical) |
| `webflow-v1-api-token` | ❌ | ✅ (via canonical) |
| Bundled default ruleset (`gcp-api-key`, `generic-api-key`, etc.) | ❌ | ✅ (chained via canonical) |

## Allowlist

Universal baseline plus `tncld`-specific `js/webflow.js`:

- `(.*/)?\.env\.example$`, `\.env\.template$`, `CLAUDE\.md$`, `\.gitleaks\.toml$` — universal
- `(.*/)?js/webflow\.js$` — Webflow's bundled JS runtime ships with public client-side identifiers (Google Maps API key for the map widget) that fire on `gcp-api-key`. Verified to be Webflow's product, not Brik secrets.

## Test plan

- [x] `gitleaks detect --config=.gitleaks.toml --no-git --redact` scans the working tree with `no leaks found` (was 1 finding before allowlist landed)
- [ ] CI workflow scans the PR diff — green on PR
- [ ] After merge: `sync.sh --diff` from brik-llm returns 0 drift for `tncld`

## Related

- brikdesigns/brik-llm#625 — security backlog consolidation (PUBLIC repo gitleaks gap)
- brikdesigns/brik-llm#706 — cluster H propagation infrastructure
- brikdesigns/brik-llm#707 — recipe fix (extend chain semantics)
- brikdesigns/brik-llm#713 — sync.sh worktree-basename fix (made the {REPO_NAME} bootstrap substitution resolve correctly when run from a worktree)
- brikdesigns/brikdesigns#296 — companion fourth migration shipped in the same session

🤖 Generated with [Claude Code](https://claude.com/claude-code)