### PR TITLE
chore(security): acknowledge history-only secret findings; allowlist FPs

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -38,4 +38,9 @@ paths = [
   # (e.g. Google Maps API key for the map widget) that fire on `gcp-api-key`.
   # These are baked into Webflow's product, not Brik secrets — safe to skip.
   '''(.*/)?js/webflow\.js$''',
+  # Tokens Studio config uses a `${FIGMA_ACCESS_TOKEN}` env-var placeholder,
+  # never a live value (brik-llm#1354).
+  '''(.*/)?json/tokens-studio-config\.json$''',
+  # Figma setup doc — placeholder tokens in copy-paste instructions, not live.
+  '''(.*/)?markdown/resources/FIGMA_SETUP\.md$''',
 ]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,16 @@
+# .gitleaksignore — acknowledged gitleaks findings.
+# Format: <commit>:<file>:<rule>:<startline>  (see secret-scan-triage.sh).
+#
+# Accepted per brik-llm#1354 (structural fix only, no rotation): these are real
+# Notion + Webflow API tokens that were hardcoded in an early commit and later
+# refactored to process.env.* (current HEAD reads from env — verified clean).
+# The values remain only in this PRIVATE repo's git history, which per
+# brik-secrets doctrine (operations/security/when-to-rotate.md) is a
+# structural-fix trigger, not an external-exposure or rotation trigger. HEAD is
+# clean; these fingerprints stop the weekly full-history scan re-paging #security.
+0c99e520f4b73787156b6a44948e0d2a4b8a16c0:js/count-contacts.js:notion-api-token:3
+0c99e520f4b73787156b6a44948e0d2a4b8a16c0:js/count-contacts.js:notion-integration-token:3
+0c99e520f4b73787156b6a44948e0d2a4b8a16c0:js/list-notion-databases.js:notion-api-token:4
+0c99e520f4b73787156b6a44948e0d2a4b8a16c0:js/list-notion-databases.js:notion-integration-token:4
+0c99e520f4b73787156b6a44948e0d2a4b8a16c0:js/publish-webflow-test.js:webflow-v1-api-token:3
+0c99e520f4b73787156b6a44948e0d2a4b8a16c0:js/publish-webflow.js:webflow-v1-api-token:4


### PR DESCRIPTION
Part of brikdesigns/brik-llm#1354 (structural fix only; no rotation).

## What
All tncld gitleaks findings are **history-only** — current HEAD already reads every token from `process.env.*`. The real Notion + Webflow tokens survive only in this **private** repo's git history, which per brik-secrets doctrine (`when-to-rotate.md`) is a structural-fix trigger, not an exposure/rotation trigger.

- **`.gitleaksignore`** — acknowledge the 6 real-token fingerprints (commit `0c99e520`): `count-contacts.js`, `list-notion-databases.js`, `publish-webflow.js`, `publish-webflow-test.js`.
- **`.gitleaks.toml`** — allowlist `tokens-studio-config.json` (`${FIGMA_ACCESS_TOKEN}` placeholder) + `FIGMA_SETUP.md` (doc placeholders).

## Verification
`gitleaks detect --source=. --config=.gitleaks.toml` → **0 findings** (6 real tokens present with the ignore file removed; 0 with it). No code changes — HEAD was already env-based.

🤖 Generated with [Claude Code](https://claude.com/claude-code)